### PR TITLE
LPS-178452 Revert code of Migrate the Segmentation Editor to the Control Panel Epic

### DIFF
--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/test/SegmentsEntryServiceTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/test/SegmentsEntryServiceTest.java
@@ -395,11 +395,15 @@ public class SegmentsEntryServiceTest {
 			SegmentsEntryConstants.SOURCE_ASAH_FARO_BACKEND,
 			RandomTestUtil.randomString(), serviceContext);
 
-		_segmentsEntryService.updateSegmentsEntry(
-			segmentsEntry.getSegmentsEntryId(),
-			segmentsEntry.getSegmentsEntryKey(), segmentsEntry.getNameMap(),
-			segmentsEntry.getDescriptionMap(), segmentsEntry.isActive(),
-			segmentsEntry.getCriteria(), serviceContext);
+		try (ContextUserReplace contextUserReplace = new ContextUserReplace(
+				_groupUser, PermissionCheckerFactoryUtil.create(_groupUser))) {
+
+			_segmentsEntryService.updateSegmentsEntry(
+				segmentsEntry.getSegmentsEntryId(),
+				segmentsEntry.getSegmentsEntryKey(), segmentsEntry.getNameMap(),
+				segmentsEntry.getDescriptionMap(), segmentsEntry.isActive(),
+				segmentsEntry.getCriteria(), serviceContext);
+		}
 	}
 
 	@Test(expected = PrincipalException.MustHavePermission.class)

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/web/internal/portlet/action/test/EditSegmentsEntryMVCRenderCommandTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/web/internal/portlet/action/test/EditSegmentsEntryMVCRenderCommandTest.java
@@ -121,7 +121,6 @@ public class EditSegmentsEntryMVCRenderCommandTest {
 
 		Assert.assertTrue(formId.endsWith("editSegmentFm"));
 
-		Assert.assertEquals(_group.getGroupId(), (long)props.get("groupId"));
 		Assert.assertTrue((boolean)props.get("hasUpdatePermission"));
 		Assert.assertEquals(0, (int)props.get("initialMembersCount"));
 		Assert.assertFalse((boolean)props.get("initialSegmentActive"));
@@ -138,7 +137,6 @@ public class EditSegmentsEntryMVCRenderCommandTest {
 			_group.getDescriptiveName(), props.get("scopeName"));
 		Assert.assertNotNull(props.get("segmentsConfigurationURL"));
 		Assert.assertTrue((boolean)props.get("showInEditMode"));
-		Assert.assertNotNull(props.get("siteItemSelectorURL"));
 	}
 
 	@Test

--- a/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/application/list/SegmentsPanelApp.java
+++ b/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/application/list/SegmentsPanelApp.java
@@ -18,24 +18,24 @@ import com.liferay.application.list.BasePanelApp;
 import com.liferay.application.list.PanelApp;
 import com.liferay.application.list.constants.PanelCategoryKeys;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
-import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.segments.constants.SegmentsPortletKeys;
 
-import org.osgi.framework.BundleContext;
-import org.osgi.framework.ServiceRegistration;
-import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Eduardo García
  */
-@Component(service = {})
+@Component(
+	property = {
+		"panel.app.order:Integer=300",
+		"panel.category.key=" + PanelCategoryKeys.SITE_ADMINISTRATION_MEMBERS
+	},
+	service = PanelApp.class
+)
 public class SegmentsPanelApp extends BasePanelApp {
 
 	@Override
@@ -47,9 +47,7 @@ public class SegmentsPanelApp extends BasePanelApp {
 	public boolean isShow(PermissionChecker permissionChecker, Group group)
 		throws PortalException {
 
-		if (!FeatureFlagManagerUtil.isEnabled("LPS-166954") &&
-			(group.isLayoutSetPrototype() || group.isUser())) {
-
+		if (group.isLayoutSetPrototype() || group.isUser()) {
 			return false;
 		}
 
@@ -64,39 +62,5 @@ public class SegmentsPanelApp extends BasePanelApp {
 	public void setPortlet(Portlet portlet) {
 		super.setPortlet(portlet);
 	}
-
-	@Activate
-	protected void activate(BundleContext bundleContext) {
-		if (!FeatureFlagManagerUtil.isEnabled("LPS-166954")) {
-			_serviceRegistration = bundleContext.registerService(
-				PanelApp.class, this,
-				HashMapDictionaryBuilder.<String, Object>put(
-					"panel.app.order", 300
-				).put(
-					"panel.category.key",
-					PanelCategoryKeys.SITE_ADMINISTRATION_MEMBERS
-				).build());
-		}
-		else {
-			_serviceRegistration = bundleContext.registerService(
-				PanelApp.class, this,
-				HashMapDictionaryBuilder.<String, Object>put(
-					"panel.app.order", 800
-				).put(
-					"panel.category.key", PanelCategoryKeys.CONTROL_PANEL_USERS
-				).build());
-		}
-	}
-
-	@Deactivate
-	protected void deactivate() {
-		if (_serviceRegistration == null) {
-			return;
-		}
-
-		_serviceRegistration.unregister();
-	}
-
-	private volatile ServiceRegistration<PanelApp> _serviceRegistration;
 
 }

--- a/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/display/context/EditSegmentsEntryDisplayContext.java
+++ b/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/display/context/EditSegmentsEntryDisplayContext.java
@@ -463,7 +463,7 @@ public class EditSegmentsEntryDisplayContext {
 		long segmentsEntryId = getSegmentsEntryId();
 
 		if (segmentsEntryId > 0) {
-			_segmentsEntry = _segmentsEntryService.recalculateSegmentsEntry(
+			_segmentsEntry = _segmentsEntryService.getSegmentsEntry(
 				segmentsEntryId);
 
 			return _segmentsEntry;

--- a/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/display/context/EditSegmentsEntryDisplayContext.java
+++ b/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/display/context/EditSegmentsEntryDisplayContext.java
@@ -15,7 +15,6 @@
 package com.liferay.segments.web.internal.display.context;
 
 import com.liferay.item.selector.ItemSelector;
-import com.liferay.item.selector.criteria.URLItemSelectorReturnType;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.bean.BeanParamUtil;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -31,7 +30,6 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.module.configuration.ConfigurationException;
 import com.liferay.portal.kernel.portlet.LiferayWindowState;
-import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
@@ -53,7 +51,6 @@ import com.liferay.segments.model.SegmentsEntry;
 import com.liferay.segments.provider.SegmentsEntryProviderRegistry;
 import com.liferay.segments.service.SegmentsEntryService;
 import com.liferay.segments.web.internal.security.permission.resource.SegmentsEntryPermission;
-import com.liferay.site.item.selector.criterion.SiteItemSelectorCriterion;
 
 import java.util.HashMap;
 import java.util.List;
@@ -177,27 +174,6 @@ public class EditSegmentsEntryDisplayContext {
 		}
 
 		return _segmentsEntryKey;
-	}
-
-	public String getSiteItemSelectorURL() {
-		if (getSegmentsEntryId() != 0) {
-			return null;
-		}
-
-		SiteItemSelectorCriterion siteItemSelectorCriterion =
-			new SiteItemSelectorCriterion();
-
-		siteItemSelectorCriterion.setDesiredItemSelectorReturnTypes(
-			new URLItemSelectorReturnType());
-
-		return PortletURLBuilder.create(
-			_itemSelector.getItemSelectorURL(
-				RequestBackedPortletURLFactoryUtil.create(_renderRequest),
-				_renderResponse.getNamespace() + "sitesSelectItem",
-				siteItemSelectorCriterion)
-		).setParameter(
-			"displayStyle", "list"
-		).buildString();
 	}
 
 	public String getTitle(Locale locale) throws PortalException {
@@ -431,8 +407,6 @@ public class EditSegmentsEntryDisplayContext {
 			"segmentsConfigurationURL", _getSegmentsCompanyConfigurationURL()
 		).put(
 			"showInEditMode", _isShowInEditMode()
-		).put(
-			"siteItemSelectorURL", getSiteItemSelectorURL()
 		).build();
 	}
 

--- a/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/display/context/SegmentsDisplayContext.java
+++ b/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/display/context/SegmentsDisplayContext.java
@@ -301,35 +301,11 @@ public class SegmentsDisplayContext {
 			return _language.get(_themeDisplay.getLocale(), "global");
 		}
 
-		if (!FeatureFlagManagerUtil.isEnabled("LPS-166954")) {
-			if (segmentsEntry.getGroupId() == _themeDisplay.getScopeGroupId()) {
-				return _language.get(_themeDisplay.getLocale(), "current-site");
-			}
-
-			return _language.get(_themeDisplay.getLocale(), "parent-site");
+		if (segmentsEntry.getGroupId() == _themeDisplay.getScopeGroupId()) {
+			return _language.get(_themeDisplay.getLocale(), "current-site");
 		}
 
-		Group group = _groupLocalService.fetchGroup(segmentsEntry.getGroupId());
-
-		if (group == null) {
-			return StringPool.BLANK;
-		}
-
-		try {
-			String descriptiveName = group.getDescriptiveName(
-				_themeDisplay.getLocale());
-
-			if (descriptiveName != null) {
-				return descriptiveName;
-			}
-
-			return group.getName(_themeDisplay.getLocale());
-		}
-		catch (PortalException portalException) {
-			_log.error(portalException);
-
-			return group.getName(_themeDisplay.getLocale());
-		}
+		return _language.get(_themeDisplay.getLocale(), "parent-site");
 	}
 
 	public String getSearchActionURL() {

--- a/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/display/context/SegmentsDisplayContext.java
+++ b/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/display/context/SegmentsDisplayContext.java
@@ -328,41 +328,21 @@ public class SegmentsDisplayContext {
 		searchContainer.setOrderByType(getOrderByType());
 
 		if (_isSearch()) {
-			if (!FeatureFlagManagerUtil.isEnabled("LPS-166954")) {
-				searchContainer.setResultsAndTotal(
-					_segmentsEntryService.searchSegmentsEntries(
-						_themeDisplay.getCompanyId(),
-						_themeDisplay.getScopeGroupId(), _getKeywords(), true,
-						searchContainer.getStart(), searchContainer.getEnd(),
-						_getSort()));
-			}
-			else {
-				searchContainer.setResultsAndTotal(
-					_segmentsEntryService.searchSegmentsEntries(
-						_themeDisplay.getCompanyId(), _getKeywords(),
-						searchContainer.getStart(), searchContainer.getEnd(),
-						_getSort()));
-			}
+			searchContainer.setResultsAndTotal(
+				_segmentsEntryService.searchSegmentsEntries(
+					_themeDisplay.getCompanyId(),
+					_themeDisplay.getScopeGroupId(), _getKeywords(), true,
+					searchContainer.getStart(), searchContainer.getEnd(),
+					_getSort()));
 		}
 		else {
-			if (!FeatureFlagManagerUtil.isEnabled("LPS-166954")) {
-				searchContainer.setResultsAndTotal(
-					() -> _segmentsEntryService.getSegmentsEntries(
-						_themeDisplay.getScopeGroupId(), true,
-						searchContainer.getStart(), searchContainer.getEnd(),
-						searchContainer.getOrderByComparator()),
-					_segmentsEntryService.getSegmentsEntriesCount(
-						_themeDisplay.getScopeGroupId(), true));
-			}
-			else {
-				searchContainer.setResultsAndTotal(
-					() -> _segmentsEntryService.getSegmentsEntries(
-						_themeDisplay.getCompanyId(),
-						searchContainer.getStart(), searchContainer.getEnd(),
-						searchContainer.getOrderByComparator()),
-					_segmentsEntryService.getSegmentsEntriesCount(
-						_themeDisplay.getCompanyId()));
-			}
+			searchContainer.setResultsAndTotal(
+				() -> _segmentsEntryService.getSegmentsEntries(
+					_themeDisplay.getScopeGroupId(), true,
+					searchContainer.getStart(), searchContainer.getEnd(),
+					searchContainer.getOrderByComparator()),
+				_segmentsEntryService.getSegmentsEntriesCount(
+					_themeDisplay.getScopeGroupId(), true));
 		}
 
 		searchContainer.setRowChecker(

--- a/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/display/context/SegmentsDisplayContext.java
+++ b/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/display/context/SegmentsDisplayContext.java
@@ -26,7 +26,6 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.search.EmptyOnClickRowChecker;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -506,21 +505,12 @@ public class SegmentsDisplayContext {
 
 	public boolean isShowDeleteAction(SegmentsEntry segmentsEntry) {
 		try {
-			if (!FeatureFlagManagerUtil.isEnabled("LPS-166954")) {
-				if ((segmentsEntry.getGroupId() ==
-						_themeDisplay.getScopeGroupId()) &&
-					SegmentsEntryPermission.contains(
-						_permissionChecker, segmentsEntry, ActionKeys.DELETE)) {
+			if ((segmentsEntry.getGroupId() ==
+					_themeDisplay.getScopeGroupId()) &&
+				SegmentsEntryPermission.contains(
+					_permissionChecker, segmentsEntry, ActionKeys.DELETE)) {
 
-					return true;
-				}
-			}
-			else {
-				if (SegmentsEntryPermission.contains(
-						_permissionChecker, segmentsEntry, ActionKeys.DELETE)) {
-
-					return true;
-				}
+				return true;
 			}
 
 			return false;


### PR DESCRIPTION
Motivation
=======
It has decided to stop segmentation unification, so for that, as a tango team we have decided to revert the code from master and move it to the branch with name LPS-154036-unified-segmentation-experience. The reason to do that, is to prevent problems in the future. The code involved in this PR is related to the epic [LPS-166954-Migrate the Segmentation Editor to the Control Panel](https://issues.liferay.com/browse/LPS-166954) 

[Link to story or ticket](https://issues.liferay.com/browse/LPS-178496)
[Link to technical task](https://issues.liferay.com/browse/LPS-178074)
[Link to technical subtask](https://issues.liferay.com/browse/LPS-178452)

Proposed Solution
========
1. Revert all code from master below FF related to the epic: https://issues.liferay.com/browse/LPS-166954

Steps to Verify:
----------------
1. Keep the FF LPS-166954
2. With the administrator, Go to Control Panel / Users  and you won't see the segments management there.
4. Create a regular role called whatever you want and add the following permissions: 

- Segments / GENERAL PERMISSIONS / Access in Site and Asset Library Administration
- Segments / SEGMENTS / Manage Segments Entries

5. Add a user and add the above role to the user.
6. With the user created, go to Site Administration / People  and you will see the segments management there. 
7. Click on segments and you will see a list of segments associated to the scoped site and the Global site.
8. You only have the permissions to manage the segments that you create. So add a segment, then update it and finally delete it.
9. Add the following permissions to the created role:

- Segments / SEGMENTS ENTRY / Delete
- Segments / SEGMENTS ENTRY / Update

10. Update, delete segments created by other users.






