### PR TITLE
wip form container

### DIFF
--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/input/template/parser/FragmentEntryInputTemplateNodeContextHelper.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/input/template/parser/FragmentEntryInputTemplateNodeContextHelper.java
@@ -41,6 +41,8 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.InfoFormException;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.json.JSONException;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
@@ -95,9 +97,10 @@ public class FragmentEntryInputTemplateNodeContextHelper {
 	}
 
 	public InputTemplateNode toInputTemplateNode(
-		FragmentEntryLink fragmentEntryLink,
-		HttpServletRequest httpServletRequest, InfoForm infoForm,
-		Locale locale) {
+			FragmentEntryLink fragmentEntryLink,
+			HttpServletRequest httpServletRequest, InfoForm infoForm,
+			Locale locale)
+		throws JSONException {
 
 		String errorMessage = StringPool.BLANK;
 
@@ -271,9 +274,19 @@ public class FragmentEntryInputTemplateNodeContextHelper {
 			value = infoFormParameterMap.get(infoField.getName());
 		}
 		else {
-			value = _getValue(
+			String infoFieldValue = _getValue(
 				value, httpServletRequest, infoField, infoForm.getName(),
 				locale);
+
+			value = infoFieldValue;
+
+			if (infoFieldType instanceof RelationshipInfoFieldType) {
+				JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
+					infoFieldValue);
+
+				label = jsonObject.getString("label");
+				value = jsonObject.getString("value");
+			}
 		}
 
 		InputTemplateNode inputTemplateNode = new InputTemplateNode(
@@ -768,6 +781,12 @@ public class FragmentEntryInputTemplateNodeContextHelper {
 			if (Objects.equals(bigDecimal.signum(), 0)) {
 				return "0";
 			}
+		}
+
+		if (infoField.getInfoFieldType() ==
+				RelationshipInfoFieldType.INSTANCE) {
+
+			return String.valueOf(infoFieldValue.getValue());
 		}
 
 		if (infoField.getInfoFieldType() == SelectInfoFieldType.INSTANCE) {

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/select-from-list/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/select-from-list/index.html
@@ -15,7 +15,7 @@
 				<div class="input-group-item input-group-prepend">
 					<input aria-autocomplete="list" aria-controls="${fragmentEntryLinkNamespace}-listbox" aria-expanded="false" aria-labelledby="${fragmentEntryLinkNamespace}-select-from-list-input-label [#if  input.errorMessage?has_content]${fragmentEntryLinkNamespace}-select-from-list-input-error-message[/#if]" class="form-control" id="${fragmentEntryLinkNamespace}-select-from-list-input" name="" placeholder="${languageUtil.get(locale, "choose-an-option")}" role="combobox" type="text" ${input.required?then('required', '')} [#if input.attributes.selectedOptionLabel??]value="${input.attributes.selectedOptionLabel}"[/#if] />
 
-					<input id="${fragmentEntryLinkNamespace}-value-input" name="${input.name}" type="hidden" [#if input.attributes.selectedOptionValue??]value="${input.value}"[/#if] />
+					<input id="${fragmentEntryLinkNamespace}-value-input" name="${input.name}" type="hidden" [#if input.value??]value="${input.value}"[/#if] />
 					<input id="${fragmentEntryLinkNamespace}-label-input" name="${input.name}-label" type="hidden" [#if input.attributes.selectedOptionLabel??]value="${input.attributes.selectedOptionLabel}"[/#if] />
 				</div>
 

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/select-from-list/index.js
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/select-from-list/index.js
@@ -51,25 +51,27 @@ window.addEventListener('scroll', handleWindowResizeOrScroll, {
 
 let lastSearchAbortController = new AbortController();
 let lastSearchQuery = null;
-valueInputElement.value = '';
+
 
 if (input.value) {
 	const selectedOption = (input.attributes.options || []).find(
 		(option) => option.value === input.value
 	);
 
-	lastSearchQuery = selectedOption.label.toLowerCase();
-	valueInputElement.value = selectedOption.value;
+	if (selectedOption) {
+		lastSearchQuery = selectedOption.label.toLowerCase();
+		valueInputElement.value = selectedOption.value;
 
-	const selectedOptionElement = optionListElement.querySelector(
-		'.active.dropdown-item'
-	);
-
-	if (selectedOptionElement) {
-		optionListElement.setAttribute(
-			'aria-activedescendant',
-			selectedOption.id
+		const selectedOptionElement = optionListElement.querySelector(
+			'.active.dropdown-item'
 		);
+
+		if (selectedOptionElement) {
+			optionListElement.setAttribute(
+				'aria-activedescendant',
+				selectedOption.id
+			);
+		}
 	}
 }
 

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/util/ObjectEntryUtil.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/util/ObjectEntryUtil.java
@@ -26,6 +26,7 @@ import com.liferay.object.scope.ObjectScopeProvider;
 import com.liferay.object.scope.ObjectScopeProviderRegistry;
 import com.liferay.object.service.ObjectEntryLocalServiceUtil;
 import com.liferay.object.service.ObjectRelationshipLocalServiceUtil;
+import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.util.DateUtil;
@@ -153,8 +154,13 @@ public class ObjectEntryUtil {
 					fetchObjectRelationshipByObjectFieldId2(
 						objectField.getObjectFieldId());
 
-			return ObjectEntryLocalServiceUtil.getTitleValue(
-				objectRelationship.getObjectDefinitionId1(), primaryKey);
+			return JSONUtil.put(
+				"label",
+				ObjectEntryLocalServiceUtil.getTitleValue(
+					objectRelationship.getObjectDefinitionId1(), primaryKey)
+			).put(
+				"value", primaryKey
+			);
 		}
 
 		return value;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-203883 Link to bug

## Steps to reproduce

- Go to Objects and create 2 objects (Company and Employee) 
- Add a One to Many Relationship from Company (One) to Employee (Many)
- Add an entry for Company and Employee
- Add a Form Container to a display page template for Employee object
- Map the Form Container to Employee
- Publish the display page template
- Mark the display page template as default
- Add a Button fragment to a content page
- Select the Mapped URL in Link tab
- In Item select the entry created for Employee
- In field input select default
- Publish the content page
- Navigate to the content page at view mode
- Click the Button
- View the value of object entry is shown on Form
- In the relationship input select the entry and submit the form 
- Go to Content Page in view mode and click button 
- See the value of relationship is not selected

https://github.com/Mikellorza/liferay-portal/assets/91208451/b956b6e7-3e34-47e1-b2b9-48174d17810b

## Context

Lo que he hecho en **ObjectEntryUtil.java** lo he hecho porque necesito la "primaryKey" para que el dato se muestre bien en el input, por eso he construido un JSON con la label y el value.

NOTE: con mis cambios, el valor sale bien en el input de la relación, pero si al Content Page le añado un párrafo y lo mapeo a la relación, el valor del párrafo sale mal (ver captura). Esto pasa porque en **ObjectEntryUtil.java** en la función **getValue** devuelvo un JSON cuando es una relación, pero se ve que esa función se usa en más sitios (EditableDocumentFragmentEntryProcessor.java en el caso del párrafo) y ya no sé cómo arreglarlo. Porque lo que necesito es la "primaryKey" que se obtiene en esa función.
<img width="328" alt="Screenshot 2023-12-20 at 15 28 50" src="https://github.com/Mikellorza/liferay-portal/assets/91208451/95f494d8-3901-45b9-8f63-85a362ffe5bf">

