### PR TITLE
LPP-54642 If the configuration of index all article versions is disab…

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/spi/model/index/contributor/JournalArticleModelIndexerWriterContributor.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/spi/model/index/contributor/JournalArticleModelIndexerWriterContributor.java
@@ -209,12 +209,6 @@ public class JournalArticleModelIndexerWriterContributor
 	}
 
 	private void _reindexOtherArticleVersions(JournalArticle journalArticle) {
-		if (PortalUtil.getClassNameId(DDMStructure.class) ==
-				journalArticle.getClassNameId()) {
-
-			return;
-		}
-
 		List<JournalArticle> journalArticles =
 			_journalArticleLocalService.getArticles(
 				journalArticle.getGroupId(), journalArticle.getArticleId(),
@@ -226,7 +220,10 @@ public class JournalArticleModelIndexerWriterContributor
 
 		for (JournalArticle versionJournalArticle : journalArticles) {
 			if (Objects.equals(
-					versionJournalArticle.getId(), journalArticle.getId())) {
+					versionJournalArticle.getId(), journalArticle.getId()) ||
+				(!_isIndexAllArticleVersions() &&
+				 (versionJournalArticle.getVersion() >=
+					 journalArticle.getVersion()))) {
 
 				continue;
 			}


### PR DESCRIPTION
This is a workaround about improve the performance when we are indexing versions of contents. When we have the configuration disable about index all versions we don't need to index some versions. About this, I've observed two use cases:

1. When we have some versions and we expire the last version, so we need to index the previous one version. I observed that with this change it is working fine, but it would be fine a double check.
2. When we have  also the configuration "Version History by Default Enabled"=disabled and "Journal Article Maximum Version Count"= 1, so in this case we are expiring the previous version when we are adding a new one, so in this case, with this development we don't call to index versions with higher version than the version that we are indexing, so, we are not re-indexing the version recently created in the expiration. This development also allow to delete previous versions from the index when we have the "index all versions" configuration disabled. Furthermore, If we use the condition if we have disable "Version History by Default Enabled" configuration instead of the version condition we will never delete from the index previous versions.

